### PR TITLE
IE11에서 scope.$apply 실행시 오류 발생되어 $rootScope.$$phase 조건으로 판단하도록 수정

### DIFF
--- a/src/angular-summernote.js
+++ b/src/angular-summernote.js
@@ -40,7 +40,7 @@ angular.module('summernote', [])
         var newValue = element.code();
         if (ngModel && ngModel.$viewValue !== newValue) {
           ngModel.$setViewValue(newValue);
-          if (scope.$root.$$phase ) {
+          if (!scope.$root.$$phase) {
             scope.$apply();
           }
         }

--- a/src/angular-summernote.js
+++ b/src/angular-summernote.js
@@ -40,7 +40,7 @@ angular.module('summernote', [])
         var newValue = element.code();
         if (ngModel && ngModel.$viewValue !== newValue) {
           ngModel.$setViewValue(newValue);
-          if (scope.$$phase !== '$apply' && scope.$$phase !== '$digest' ) {
+          if (scope.$root.$$phase ) {
             scope.$apply();
           }
         }


### PR DESCRIPTION
안녕하세요. outsider님 
summernote angular version을 애용하고 있는 평범한 개발자 중 한사람입니다.

최근 IE에서 테스트를 하다 페이지 로딩 시 계속적인 angular exception이 나서 원인을 찾아 봤는데요.
Error: [$rootScope:inprog] $digest already in progress

angular의 dirty checking에서 $$phase 조건범위가 해당 scope이 아닌 $rootScope의 처리로 되어야 함을 angular 1.2.28 소스 코드를 통해 알게 되었습니다.
```
if (ctrl.$viewValue !== value || (value === '' && revalidate)) {
      if (scope.$root.$$phase) {
        ctrl.$setViewValue(value);
      } else {
        scope.$apply(function() {
          ctrl.$setViewValue(value);
        });
      }
    }
```
확인해 보시고 반영 부탁드리겠습니다.

ps. 많은 도움 받고 있습니다. ^^