### PR TITLE
Fixed two WARN massages when run npm install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,7 @@
     "type": "git",
     "url": "https://github.com/outsideris/involved.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://outsider.mit-license.org/"
-    }
-  ],
+  "license": "MIT",
   "devDependencies": {
     "del": "^2.1.0",
     "gulp": "^3.9.0",
@@ -47,6 +42,7 @@
     "karma-requirejs": "~0.2.1",
     "karma-script-launcher": "~0.1.0",
     "mocha": "~2.2.0",
+    "phantomjs": "^2.1.7",
     "requirejs": "~2.1.10"
   },
   "dependencies": {}


### PR DESCRIPTION
- Fixed npm WARN angular-summernote@0.8.1 No license field:
  - Change License meta data format
  - Reference: https://docs.npmjs.com/files/package.json#license

- Fixed npm WARN karma-phantomjs-launcher@0.2.3 requires a peer of phantomjs@>=1.9 but none was installed.
  - Add phantomjs in devDependencies